### PR TITLE
Checkout branch if specified

### DIFF
--- a/setup
+++ b/setup
@@ -353,12 +353,17 @@ install_repos() {
       continue
     fi
 
+    ## Check out desired branch
+    if [[ -v repo[branch ]]; then
+      run "cd ${target}; git checkout ${repo[branch]}"
+    fi
+
     # Handle submodules
     run "cd ${target}; git submodule update --init --recursive" ;
     run "cd ${target}; git submodule foreach --recursive git checkout master"
 
     # Execute any post-install script
-    if [[ -n "${repo[script]}" ]]; then
+    if [[ -v repo[script] ]]; then
       run "( cd ${target} ; ${repo[script]} )"
     fi
   done


### PR DESCRIPTION
**Goal:**
Allow user to specify what branch they want repos checked out to.

**Changes:**
- Add optional "branch" config to `repos.json`
- Do a git checkout after cloning if a branch was specified.

**Notes:**
- submodules will still be checked out to master